### PR TITLE
fix handling of multiple pods

### DIFF
--- a/src/Kubycat.ts
+++ b/src/Kubycat.ts
@@ -273,12 +273,16 @@ class Kubycat {
 
                     child.stdout.setEncoding('utf8');
                     child.stdout.on('data', (data) => {
-                        output.push(data.toString());
+                        for (const line of data.toString().split(/(\r?\n)/g)) {
+                            output.push(line);
+                        }
                     });
 
                     child.stderr.setEncoding('utf8');
                     child.stderr.on('data', (data) => {
-                        error.push(data.toString());
+                        for (const line of data.toString().split(/(\r?\n)/g)) {
+                            error.push(line);
+                        }
                     });
 
                     child.on('exit', (code) => {


### PR DESCRIPTION
This pushes each line of the `stdout` and `stderr` of a child process into the respective arrays. It fixes issue #2 .